### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/laravel/setup.md
+++ b/laravel/setup.md
@@ -39,5 +39,5 @@ export PATH="~/.composer/vendor/bin:$PATH"
 ### 延伸閱讀
 
 * [小信豬的原始部落: BASH 打造自己的 shell 環境 (2) - Shell Option](http://godleon.blogspot.tw/2007/05/linux-bash-process-file-alias-shell.html)
-* [如何在OS X安裝Homestead? | 點燈坊](http://oomusou.io/laravel/homestead/homestead-osx/)
+* [如何在OS X安裝Homestead? | 點燈坊](https://old-oomusou.goodjack.tw/laravel/homestead/homestead-macos/)
 * [文件 - Composer | 正體中文文件](https://getcomposer.ycnets.com/doc/)


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw